### PR TITLE
Stop polling when workout is done

### DIFF
--- a/app.js
+++ b/app.js
@@ -722,6 +722,10 @@ class VitruvianApp {
 
   completeWorkout() {
     if (this.currentWorkout) {
+      // Stop polling to prevent queue buildup
+      this.device.stopPropertyPolling();
+      this.device.stopMonitorPolling();
+
       // Set end time
       const endTime = new Date();
       this.currentWorkout.endTime = endTime;


### PR DESCRIPTION
## Problem

Polling intervals (monitor every 100ms, property every 500ms) continue running after each exercise set is completed, accumulating hundreds of queued GATT operations during rest periods. This causes the "Start Program" command for subsequent sets to wait behind all queued operations, creating 30+ second delays (increasing over time).

## Steps to Reproduce

1. On the app, I click "Connect to Device" and pair Chrome with machine.
2. I change only the "weight per cable" value.
3. I click "Start Program" and the command is immediately acknowledged by the machine.
4. I perform the set.
5. I rest a couple minutes, then set a new "weight per cable" value.
6. I click "Start Program" and the command is not sent until roughly 30 seconds later.
7. Perform set and rest. Next "Start Program" command takes even longer to acknowledge.

## Fix

Added polling stops in `completeWorkout()` which is called by all completion paths:

- Manual stop via STOP button
- Auto-completion when target reps reached
- Auto-completion at top of final rep (when stopAtTop enabled)